### PR TITLE
fix: 针对280版本功能修复

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,23 +34,23 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.54-GTNH:dev")
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.8.2:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-beta29:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:2.1.40:dev')
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.64-GTNH:dev")
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.8.12:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-beta49:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:5.1.55:dev')
 
     // use GTNH274 version
     // Lib
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.5.23:dev")
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.37:dev")
 
     // AE
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-485-GTNH:dev')
-    api('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.3.55-gtnh:dev') {
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-658-GTNH:dev')
+    api('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.100-gtnh:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }
 
     // GT
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.50.119:dev'){
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.389:dev'){
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
         exclude group: 'com.github.GTNewHorizons', module: 'AE2FluidCraft-Rework'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -82,7 +82,7 @@ usesMixins = true
 separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
-usesMixinDebug = false
+usesMixinDebug = true
 
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin = coremod.MixinPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,5 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.37'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
 }

--- a/src/main/java/moe/takochan/takotech/common/CommonProxy.java
+++ b/src/main/java/moe/takochan/takotech/common/CommonProxy.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import moe.takochan.takotech.client.gui.GuiType;
+import moe.takochan.takotech.common.event.ItemTooltipEventHandler;
 import moe.takochan.takotech.common.event.PlayerDestroyItemEventHandler;
 import moe.takochan.takotech.common.event.RenderGameOverlayEventHandler;
 import moe.takochan.takotech.common.event.WorldEventHandler;
@@ -28,6 +29,7 @@ public class CommonProxy {
         MinecraftForge.EVENT_BUS.register(new WorldEventHandler());
         MinecraftForge.EVENT_BUS.register(new RenderGameOverlayEventHandler());
         MinecraftForge.EVENT_BUS.register(new PlayerDestroyItemEventHandler());
+        MinecraftForge.EVENT_BUS.register(new ItemTooltipEventHandler());
         // 配置初始化
         TakoTechConfig.init();
         // ModLoader

--- a/src/main/java/moe/takochan/takotech/common/event/ItemTooltipEventHandler.java
+++ b/src/main/java/moe/takochan/takotech/common/event/ItemTooltipEventHandler.java
@@ -1,0 +1,48 @@
+package moe.takochan.takotech.common.event;
+
+import static moe.takochan.takotech.client.settings.GameSettings.selectTool;
+
+import java.util.List;
+
+import net.minecraft.client.settings.GameSettings;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.items.MetaGeneratedTool;
+import moe.takochan.takotech.constants.NBTConstants;
+import moe.takochan.takotech.constants.NameConstants;
+import moe.takochan.takotech.utils.CommonUtils;
+import moe.takochan.takotech.utils.I18nUtils;
+
+public class ItemTooltipEventHandler {
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void onTooltip(ItemTooltipEvent event) {
+        ItemStack stack = event.itemStack;
+        List<String> tooltips = event.toolTip;
+        if (stack != null) {
+            if (stack.getItem() instanceof MetaGeneratedTool) {
+                addToolBoxTip(stack, tooltips);
+            }
+        }
+
+    }
+
+    private void addToolBoxTip(ItemStack aStack, List<String> aList) {
+        // 获取物品的 NBT 数据
+        NBTTagCompound nbt = CommonUtils.openNbtData(aStack);
+        // 检查是否存在工具箱数据和槽位数据
+        if (!nbt.hasKey(NBTConstants.TOOLBOX_DATA) || !nbt.hasKey(NBTConstants.TOOLBOX_SLOT)) return;
+        // 添加工具箱的描述信息
+        aList.add("");
+        aList.add(
+            I18nUtils.tooltip(
+                NameConstants.ITEM_TOOLBOX_PLUS_DESC,
+                GameSettings.getKeyDisplayString(selectTool.getKeyCode())));
+    }
+}

--- a/src/main/java/moe/takochan/takotech/common/storage/inventory/OreStorageCellInventory.java
+++ b/src/main/java/moe/takochan/takotech/common/storage/inventory/OreStorageCellInventory.java
@@ -258,6 +258,11 @@ public class OreStorageCellInventory implements ITakoCellInventory {
         return Long.MAX_VALUE;
     }
 
+    @Override
+    public long getRemainingItemsCountDist(IAEItemStack l) {
+        return Long.MAX_VALUE;
+    }
+
     /**
      * 获取元件未使用的物品数量。
      *

--- a/src/main/java/moe/takochan/takotech/coremod/LateMixinLoader.java
+++ b/src/main/java/moe/takochan/takotech/coremod/LateMixinLoader.java
@@ -34,7 +34,6 @@ public class LateMixinLoader implements ILateMixinLoader {
         if (map.containsKey("gregtech")) {
             if (isClient) {
                 mixins.add("gt.MetaGeneratedToolRendererMixin");
-                mixins.add("gt.MetaBaseItemMixin");
             }
             mixins.add("gt.MetaGeneratedToolMixin");
         }

--- a/src/main/java/moe/takochan/takotech/coremod/mixin/gt/MetaGeneratedToolMixin.java
+++ b/src/main/java/moe/takochan/takotech/coremod/mixin/gt/MetaGeneratedToolMixin.java
@@ -4,8 +4,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import gregtech.api.items.MetaGeneratedTool;
 import moe.takochan.takotech.constants.NBTConstants;
@@ -14,47 +15,24 @@ import moe.takochan.takotech.utils.CommonUtils;
 @Mixin(value = MetaGeneratedTool.class, remap = false)
 public abstract class MetaGeneratedToolMixin {
 
-    @Invoker("getContainerItem")
-    public abstract ItemStack invokerGetContainerItem(ItemStack aStack, boolean playSound);
-
-    /**
-     * 覆写容器物品存在判断逻辑 当工具耐久耗尽且包含工具箱数据时返回true
-     *
-     * @author XSana
-     * @reason 支持工具箱系统特殊逻辑
-     */
-    @Overwrite
-    public final boolean hasContainerItem(ItemStack aStack) {
-        final ItemStack simulatedResult = invokerGetContainerItem(aStack, false);
-
-        if ((simulatedResult == null || simulatedResult.stackSize <= 0)) {
-            final NBTTagCompound rootTag = CommonUtils.openNbtData(aStack);
-            return rootTag.hasKey(NBTConstants.TOOLBOX_DATA);
-        }
-
-        return true;
-    }
-
     /**
      * 覆写获取容器物品逻辑 当耐久耗尽时返回配置的工具箱物品
      *
      * @author XSana
      * @reason 实现工具箱物品自动回收功能
      */
-    @Overwrite
-    public final ItemStack getContainerItem(ItemStack aStack) {
-        final ItemStack vanillaResult = invokerGetContainerItem(aStack, true);
+    @Inject(method = "getContainerItem", at = @At("RETURN"), cancellable = true)
+    public void getContainerItem(ItemStack aStack, CallbackInfoReturnable<ItemStack> cir) {
+        final ItemStack vanillaResult = cir.getReturnValue();
 
-        // 仅当原版容器物品无效时处理工具箱逻辑
         if (vanillaResult == null || vanillaResult.stackSize <= 0) {
             final NBTTagCompound rootTag = CommonUtils.openNbtData(aStack);
 
             if (rootTag.hasKey(NBTConstants.TOOLBOX_DATA)) {
                 final NBTTagCompound toolboxItems = rootTag.getCompoundTag(NBTConstants.TOOLBOX_DATA);
-                return ItemStack.loadItemStackFromNBT(toolboxItems);
+                cir.setReturnValue(ItemStack.loadItemStackFromNBT(toolboxItems));
             }
         }
-
-        return vanillaResult;
     }
+
 }


### PR DESCRIPTION
- 在 CommonProxy 中注册 ItemTooltipEventHandler
- 新增 ItemTooltipEventHandler 类，用于在客户端显示工具箱物品提示
- 更新 dependencies.gradle 中的依赖版本
- 修改 MetaGeneratedToolMixin，工具箱物品回收逻辑
- 在 OreStorageCellInventory 中实现 getRemainingItemsCountDist 方法
- 更新 gtnhsettingsconvention 插件版本