### PR TITLE
build(dependencies): 更新依赖项到GTNH280-RC1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,23 +34,23 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.6.69-GTNH:dev")
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.8.12:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-beta53:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:2.1.57:dev')
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.87-GTNH:dev")
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.8.14:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-beta56:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:ServerUtilities:2.1.61:dev')
 
-    // use GTNH288-beta2 version
+    // use GTNH280-rc1 version
     // Lib
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.38:dev")
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.39:dev")
 
     // AE
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-669-GTNH:dev')
-    api('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.106-gtnh:dev') {
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-688-GTNH:dev')
+    api('com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.114-gtnh:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }
 
     // GT
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.418:dev') {
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.459:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
         exclude group: 'com.github.GTNewHorizons', module: 'AE2FluidCraft-Rework'
     }


### PR DESCRIPTION
更新 NotEnoughItems、waila、Angelica、ServerUtilities、GTNHLib、Applied-Energistics-2-Unofficial、AE2FluidCraft-Rework 和 GT5-Unofficial 到GTNH280-RC1版本