### PR TITLE
feat(client): 添加 Windows IME 自动控制功能

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,10 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
+    // JNA for Windows IME control
+    shadowImplementation('net.java.dev.jna:jna:5.14.0')
+    shadowImplementation('net.java.dev.jna:jna-platform:5.14.0')
+
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.87-GTNH:dev")
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.8.14:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:1.0.0-beta56:dev')

--- a/gradle.properties
+++ b/gradle.properties
@@ -104,7 +104,7 @@ forceEnableMixins = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated into your jar. It is your
 # responsibility to check the license and request permission for distribution if required.
-usesShadowedDependencies = false
+usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.

--- a/src/main/java/moe/takochan/takotech/client/ClientProxy.java
+++ b/src/main/java/moe/takochan/takotech/client/ClientProxy.java
@@ -1,8 +1,11 @@
 package moe.takochan.takotech.client;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import moe.takochan.takotech.client.input.IMEControl;
+import moe.takochan.takotech.client.input.IMEStateHandler;
 import moe.takochan.takotech.client.renderer.RenderSystem;
 import moe.takochan.takotech.client.settings.GameSettings;
 import moe.takochan.takotech.common.CommonProxy;
@@ -26,6 +29,14 @@ public class ClientProxy extends CommonProxy {
         // 创建游戏设置实例并注册按键绑定
         GameSettings gameSettings = new GameSettings();
         gameSettings.register();
+
+        // 初始化 IME 控制 (每 tick 检查文本框焦点状态)
+        IMEControl.init();
+        if (IMEControl.isAvailable()) {
+            FMLCommonHandler.instance()
+                .bus()
+                .register(new IMEStateHandler());
+        }
     }
 
     @Override

--- a/src/main/java/moe/takochan/takotech/client/gui/config/TakoTechGuiConfig.java
+++ b/src/main/java/moe/takochan/takotech/client/gui/config/TakoTechGuiConfig.java
@@ -6,7 +6,6 @@ import com.gtnewhorizon.gtnhlib.config.ConfigException;
 import com.gtnewhorizon.gtnhlib.config.SimpleGuiConfig;
 
 import moe.takochan.takotech.common.Reference;
-import moe.takochan.takotech.config.TakoTechConfig;
 
 /**
  * 模组配置界面GUI
@@ -14,6 +13,7 @@ import moe.takochan.takotech.config.TakoTechConfig;
 public class TakoTechGuiConfig extends SimpleGuiConfig {
 
     public TakoTechGuiConfig(GuiScreen parent) throws ConfigException {
-        super(parent, TakoTechConfig.class, Reference.MODID, Reference.MODNAME);
+        // 使用无参版本，自动获取所有已注册的配置类
+        super(parent, Reference.MODID, Reference.MODNAME);
     }
 }

--- a/src/main/java/moe/takochan/takotech/client/input/IMEControl.java
+++ b/src/main/java/moe/takochan/takotech/client/input/IMEControl.java
@@ -1,0 +1,178 @@
+package moe.takochan.takotech.client.input;
+
+import org.lwjgl.LWJGLUtil;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.win32.StdCallLibrary;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import moe.takochan.takotech.TakoTechMod;
+
+/**
+ * Windows IME (输入法) 控制工具类。
+ * 用于在游戏非输入状态时禁用输入法，避免 WASD 等按键被输入法拦截。
+ *
+ * <p>
+ * 通过 KeyboardMixin hook {@code Keyboard.enableRepeatEvents()} 实现自动控制:
+ * </p>
+ * <ul>
+ * <li>enableRepeatEvents(true) → 启用 IME (需要文本输入)</li>
+ * <li>enableRepeatEvents(false) → 禁用 IME (不需要文本输入)</li>
+ * </ul>
+ */
+@SideOnly(Side.CLIENT)
+public final class IMEControl {
+
+    private static final boolean IS_WINDOWS = LWJGLUtil.getPlatform() == LWJGLUtil.PLATFORM_WINDOWS;
+
+    /** IMM32 库接口 */
+    private interface Imm32 extends StdCallLibrary {
+
+        Imm32 INSTANCE = IS_WINDOWS ? Native.load("imm32", Imm32.class) : null;
+
+        /**
+         * 获取窗口的输入法上下文
+         */
+        Pointer ImmGetContext(HWND hwnd);
+
+        /**
+         * 释放输入法上下文
+         */
+        boolean ImmReleaseContext(HWND hwnd, Pointer hIMC);
+
+        /**
+         * 关联输入法上下文到窗口
+         *
+         * @param hwnd 窗口句柄
+         * @param hIMC 输入法上下文，null 表示禁用
+         * @return 之前关联的上下文
+         */
+        Pointer ImmAssociateContext(HWND hwnd, Pointer hIMC);
+
+        /**
+         * 关联输入法上下文（扩展版本）
+         *
+         * @param hwnd  窗口句柄
+         * @param hIMC  输入法上下文
+         * @param flags 标志位
+         */
+        boolean ImmAssociateContextEx(HWND hwnd, Pointer hIMC, int flags);
+    }
+
+    /** ImmAssociateContextEx 标志：恢复默认 IME 上下文 */
+    private static final int IACE_DEFAULT = 0x0010;
+
+    /** 保存的原始 IME 上下文 */
+    private static Pointer savedIMC = null;
+
+    /** 当前 IME 状态 */
+    private static boolean imeEnabled = true;
+
+    /** 是否已初始化 */
+    private static boolean initialized = false;
+
+    private IMEControl() {}
+
+    /**
+     * 初始化 IME 控制
+     * 应在游戏启动时调用一次
+     */
+    public static void init() {
+        if (!IS_WINDOWS || initialized) {
+            return;
+        }
+
+        try {
+            // 验证 JNA 可用
+            if (Imm32.INSTANCE == null) {
+                TakoTechMod.LOG.warn("[IMEControl] Failed to load imm32.dll");
+                return;
+            }
+
+            initialized = true;
+            TakoTechMod.LOG.info("[IMEControl] Initialized successfully");
+        } catch (Throwable e) {
+            TakoTechMod.LOG.error("[IMEControl] Failed to initialize", e);
+        }
+    }
+
+    /**
+     * 启用输入法
+     * 在打开聊天框、命令输入等需要中文输入时调用
+     */
+    public static void enableIME() {
+        if (!IS_WINDOWS || !initialized || imeEnabled) {
+            return;
+        }
+
+        try {
+            HWND hwnd = User32.INSTANCE.GetForegroundWindow();
+            if (hwnd == null) {
+                return;
+            }
+
+            if (savedIMC != null) {
+                // 恢复保存的 IME 上下文
+                Imm32.INSTANCE.ImmAssociateContext(hwnd, savedIMC);
+                savedIMC = null;
+            } else {
+                // 使用默认恢复方式
+                Imm32.INSTANCE.ImmAssociateContextEx(hwnd, null, IACE_DEFAULT);
+            }
+
+            imeEnabled = true;
+            TakoTechMod.LOG.debug("[IMEControl] IME enabled");
+        } catch (Throwable e) {
+            TakoTechMod.LOG.error("[IMEControl] Failed to enable IME", e);
+        }
+    }
+
+    /**
+     * 禁用输入法
+     * 在游戏世界中（无输入框）时调用，防止输入法拦截 WASD 等按键
+     */
+    public static void disableIME() {
+        if (!IS_WINDOWS || !initialized || !imeEnabled) {
+            return;
+        }
+
+        try {
+            HWND hwnd = User32.INSTANCE.GetForegroundWindow();
+            if (hwnd == null) {
+                return;
+            }
+
+            // 保存当前 IME 上下文
+            savedIMC = Imm32.INSTANCE.ImmGetContext(hwnd);
+            if (savedIMC != null) {
+                Imm32.INSTANCE.ImmReleaseContext(hwnd, savedIMC);
+            }
+
+            // 禁用 IME (设置上下文为 null)
+            Imm32.INSTANCE.ImmAssociateContext(hwnd, null);
+
+            imeEnabled = false;
+            TakoTechMod.LOG.debug("[IMEControl] IME disabled");
+        } catch (Throwable e) {
+            TakoTechMod.LOG.error("[IMEControl] Failed to disable IME", e);
+        }
+    }
+
+    /**
+     * 检查 IME 控制是否可用
+     */
+    public static boolean isAvailable() {
+        return IS_WINDOWS && initialized;
+    }
+
+    /**
+     * 检查 IME 当前是否启用
+     */
+    public static boolean isEnabled() {
+        return imeEnabled;
+    }
+}

--- a/src/main/java/moe/takochan/takotech/client/input/IMEStateHandler.java
+++ b/src/main/java/moe/takochan/takotech/client/input/IMEStateHandler.java
@@ -1,0 +1,64 @@
+package moe.takochan.takotech.client.input;
+
+import net.minecraft.client.Minecraft;
+
+import org.lwjgl.input.Keyboard;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import moe.takochan.takotech.config.ClientConfig;
+
+/**
+ * IME 状态处理器。
+ * 简单策略：游戏内有 GUI 时启用 IME，无 GUI 时检查输入状态。
+ * 游戏外（主菜单等）不管理 IME 状态。
+ */
+@SideOnly(Side.CLIENT)
+public class IMEStateHandler {
+
+    /** 上一次 IME 状态 */
+    private boolean lastIMEEnabled = true;
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+
+        // 检查配置是否启用
+        if (!ClientConfig.enableIMEControl) {
+            // 功能禁用时，确保 IME 恢复启用状态
+            if (!lastIMEEnabled) {
+                lastIMEEnabled = true;
+                IMEControl.enableIME();
+            }
+            return;
+        }
+
+        Minecraft mc = Minecraft.getMinecraft();
+
+        // 游戏外（主菜单、设置等）不管理，保持 IME 启用
+        if (mc.theWorld == null) {
+            if (!lastIMEEnabled) {
+                lastIMEEnabled = true;
+                IMEControl.enableIME();
+            }
+            return;
+        }
+
+        // 游戏内：有 GUI 直接启用，无 GUI 检查输入状态
+        boolean shouldEnable = mc.currentScreen != null || Keyboard.areRepeatEventsEnabled();
+
+        if (shouldEnable != lastIMEEnabled) {
+            lastIMEEnabled = shouldEnable;
+
+            if (shouldEnable) {
+                IMEControl.enableIME();
+            } else {
+                IMEControl.disableIME();
+            }
+        }
+    }
+}

--- a/src/main/java/moe/takochan/takotech/config/ClientConfig.java
+++ b/src/main/java/moe/takochan/takotech/config/ClientConfig.java
@@ -1,0 +1,17 @@
+package moe.takochan.takotech.config;
+
+import com.gtnewhorizon.gtnhlib.config.Config;
+
+import moe.takochan.takotech.common.Reference;
+
+@Config(modid = Reference.MODID, configSubDirectory = "TakoTech", filename = "client", category = "ime")
+public class ClientConfig {
+
+    @Config.Comment({ "启用 IME（输入法）自动控制功能", "开启后，游戏内无 GUI 时自动禁用输入法，防止 WASD 等按键被输入法拦截", "打开 GUI 时自动启用输入法，方便输入中文",
+        "仅在 Windows 系统上生效", "Enable automatic IME (Input Method Editor) control",
+        "When enabled, IME will be disabled when no GUI is open in-game,",
+        "preventing keys like WASD from being intercepted by the input method",
+        "IME will be enabled when a GUI is open for Chinese input", "Only works on Windows" })
+    @Config.DefaultBoolean(true)
+    public static boolean enableIMEControl;
+}

--- a/src/main/java/moe/takochan/takotech/config/TakoTechConfig.java
+++ b/src/main/java/moe/takochan/takotech/config/TakoTechConfig.java
@@ -28,6 +28,7 @@ public class TakoTechConfig {
             ConfigurationManager.registerConfig(TakoTechConfig.class);
             ConfigurationManager.registerConfig(WebControllerConfig.class);
             ConfigurationManager.registerConfig(ToolboxConfig.class);
+            ConfigurationManager.registerConfig(ClientConfig.class);
         } catch (ConfigException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary

- 游戏内无 GUI 时自动禁用输入法，防止 WASD 等按键被中文输入法拦截
- 打开 GUI 时自动启用输入法，方便输入中文
- 通过 JNA 调用 Windows IMM32 API 实现
- 仅在 Windows 系统上生效

## 配置

配置文件：`config/TakoTech/client.cfg`

```properties
# 启用 IME（输入法）自动控制功能（默认启用）
B:enableIMEControl=true
```