### PR TITLE
fix(ime): 修复切换窗口后输入法无法切换的问题

### DIFF
--- a/src/main/java/moe/takochan/takotech/client/input/IMEControl.java
+++ b/src/main/java/moe/takochan/takotech/client/input/IMEControl.java
@@ -175,4 +175,32 @@ public final class IMEControl {
     public static boolean isEnabled() {
         return imeEnabled;
     }
+
+    /**
+     * 窗口失去焦点时恢复 IME
+     * 确保切换到其他应用时输入法正常工作
+     */
+    public static void restoreIME() {
+        if (!IS_WINDOWS || !initialized || imeEnabled) {
+            return;
+        }
+
+        try {
+            HWND hwnd = User32.INSTANCE.GetForegroundWindow();
+            if (hwnd == null) {
+                return;
+            }
+
+            if (savedIMC != null) {
+                Imm32.INSTANCE.ImmAssociateContext(hwnd, savedIMC);
+                savedIMC = null;
+            } else {
+                Imm32.INSTANCE.ImmAssociateContextEx(hwnd, null, IACE_DEFAULT);
+            }
+            imeEnabled = true;
+            TakoTechMod.LOG.debug("[IMEControl] IME restored");
+        } catch (Throwable e) {
+            TakoTechMod.LOG.error("[IMEControl] Failed to restore IME", e);
+        }
+    }
 }

--- a/src/main/java/moe/takochan/takotech/client/input/IMEStateHandler.java
+++ b/src/main/java/moe/takochan/takotech/client/input/IMEStateHandler.java
@@ -3,6 +3,7 @@ package moe.takochan.takotech.client.input;
 import net.minecraft.client.Minecraft;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.opengl.Display;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
@@ -14,12 +15,16 @@ import moe.takochan.takotech.config.ClientConfig;
  * IME 状态处理器。
  * 简单策略：游戏内有 GUI 时启用 IME，无 GUI 时检查输入状态。
  * 游戏外（主菜单等）不管理 IME 状态。
+ * 窗口失去焦点时自动恢复 IME，确保其他应用可以正常输入。
  */
 @SideOnly(Side.CLIENT)
 public class IMEStateHandler {
 
     /** 上一次 IME 状态 */
     private boolean lastIMEEnabled = true;
+
+    /** 上一次窗口焦点状态 */
+    private boolean lastWindowFocused = true;
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event) {
@@ -45,6 +50,21 @@ public class IMEStateHandler {
                 lastIMEEnabled = true;
                 IMEControl.enableIME();
             }
+            return;
+        }
+
+        // 使用 LWJGL Display.isActive() 检查窗口焦点
+        boolean windowFocused = Display.isActive();
+
+        // 窗口失去焦点时恢复 IME
+        if (lastWindowFocused && !windowFocused) {
+            IMEControl.restoreIME();
+            lastIMEEnabled = true;
+        }
+        lastWindowFocused = windowFocused;
+
+        // 窗口无焦点时不管理 IME
+        if (!windowFocused) {
             return;
         }
 


### PR DESCRIPTION
- 使用 Display.isActive() 检测窗口焦点状态
- 窗口失去焦点时自动恢复 IME
- 窗口无焦点时暂停 IME 管理，避免影响其他应用